### PR TITLE
Update RollingUpdate strategy config

### DIFF
--- a/openshift-redirector.yml
+++ b/openshift-redirector.yml
@@ -16,14 +16,6 @@ objects:
       matchLabels:
         app.kubernetes.io/name: redirector
         app.kubernetes.io/component: web
-    strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10
-        updatePeriodSeconds: 1
-      type: RollingUpdate
     template:
       metadata:
         labels:


### PR DESCRIPTION
there are errors when apply current config.

```
warning: error calculating patch from openapi spec: unable to find api field "rollingParams" in io.k8s.api.apps.v1.DeploymentStrategy
```

Update config according to https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment

all default to
```
    strategy:
      type: RollingUpdate
      rollingUpdate:
        maxSurge: 25%
        maxUnavailable: 25%
```

so this config is not needed